### PR TITLE
Support both environment and environment-pattern functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Supported events are: `push`, `schedule`, `pull_request_target` and `workflow_di
 If this parameter is specified, only deployments matching the specified environment is included.
 > NOTE: The environment is calculated from the first dot delimited element in the `.bicepparam` file name. I.e. `prod` in `prod.bicepparam` or `prod.main.bicepparam`.
 
+### `environment-pattern`
+If this parameter is specified, only deployments matching the specified environment regex pattern is included.
+> NOTE: The environment is calculated from the first dot delimited element in the `.bicepparam` file name. I.e. `prod` in `prod.bicepparam` or `prod.main.bicepparam`.
+
 ### `pattern`
 If this parameter is specified, only the deployments matching the specified regex pattern is included.
 > NOTE: This pattern is matched against the deployment **directory**. I.e. `sample-deployment` in the following directory structure: `deployments/sample-deployment/prod.bicepparam`.

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: Github trigger event name.
     required: true
   environment:
+    description: Filter which environment to deploy to based on environment name.
+    required: false
+    default: ''
+  environment-pattern:
     description: Filter which environment to deploy to based on regex pattern.
     required: false
     default: .*
@@ -47,7 +51,8 @@ runs:
       env:
         deploymentsRootDirectory: ${{ steps.create-root-dir-array.outputs.deployment-root-dirs }}
         eventName: ${{ inputs.event-name }}
-        environmentPattern: ${{ inputs.environment }}
+        environment: ${{ inputs.environment }}
+        environmentPattern: ${{ inputs.environment-pattern }}
         pattern: ${{ inputs.pattern }}
         changedFiles: ${{ steps.changed-files.outputs.all_changed_files }}
         actionPath: ${{ github.action_path }}
@@ -67,6 +72,7 @@ runs:
           EventName                = $env:eventName
           ChangedFiles             = $env:changedFiles | ConvertFrom-Json -Depth 3
           Pattern                  = $env:pattern
+          Environment              = $env:environment
           EnvironmentPattern       = $env:environmentPattern
         }
 

--- a/src/DeployBicepHelpers.psm1
+++ b/src/DeployBicepHelpers.psm1
@@ -603,6 +603,9 @@ function Get-BicepDeployments {
         $Pattern, 
 
         [string]
+        $Environment, 
+
+        [string]
         $EnvironmentPattern, 
 
         [string[]]
@@ -778,6 +781,26 @@ function Get-BicepDeployments {
             #* Exclude deployments that does not match the requested environment
             if ($deploymentObject.Deploy) {
                 Write-Debug "[$deploymentName][$environmentName] Checking if environment matches desired environment."
+                if (![string]::IsNullOrEmpty($Environment)) {
+                    if ($deploymentObject.Environment -eq $Environment) {
+                        Write-Debug "[$deploymentName][$environmentName] Desired environment [$Environment] matches deployment environment [$($deploymentObject.Environment)]. Deployment included."
+                    }
+                    else {
+                        $deploymentObject.Deploy = $false
+                        Write-Debug "[$deploymentName][$environmentName] Desired environment [$Environment] does not match deployment environment [$($deploymentObject.Environment)]. Deployment not included."
+                    }
+                }
+                else {
+                    Write-Debug "[$deploymentName][$environmentName] No desired environment pattern specified. Deployment is included."
+                }
+            }
+            else {
+                Write-Debug "[$deploymentName][$environmentName] Skipping environment check. Deployment already not included."
+            }
+
+            #* Exclude deployments that does not match the requested environment pattern
+            if ($deploymentObject.Deploy) {
+                Write-Debug "[$deploymentName][$environmentName] Checking if environment matches desired environment pattern."
                 if ($EnvironmentPattern) {
                     if ($deploymentObject.Environment -match $EnvironmentPattern) {
                         Write-Debug "[$deploymentName][$environmentName] Desired environment pattern [$EnvironmentPattern] matches deployment environment [$($deploymentObject.Environment)]. Deployment included."
@@ -792,7 +815,7 @@ function Get-BicepDeployments {
                 }
             }
             else {
-                Write-Debug "[$deploymentName][$environmentName] Skipping environment check. Deployment already not included."
+                Write-Debug "[$deploymentName][$environmentName] Skipping environment pattern check. Deployment already not included."
             }
         
             #* Exclude disabled deployments


### PR DESCRIPTION
This PR fixes #17 

It adds the `environment-pattern` action parameter and matches that to the previous `$EnvironmentPattern` parameter in the PowerShell function. 

In addition, it adds a `$Environment` parameter in the PowerShell function that is mapped to the original `environment` action parameter.

While it changes the behavior of the parameters, it is considered a bugfix and thus a `patch` release as it restores behavior both intended from the start and implied by naming. 