### PR TITLE
Add tests and ensure support for multiline interpolated strings

### DIFF
--- a/src/DeployBicepHelpers.psm1
+++ b/src/DeployBicepHelpers.psm1
@@ -64,19 +64,16 @@ function Remove-BicepComments {
                 # Check for multi-line string (''' ... ''')
                 if ($j -lt $line.Length - 2 -and $line[$j + 1] -eq "'" -and $line[$j + 2] -eq "'") {
                     $j = $j + 2
-                    $prefixBeforeString = $line.Substring(0, $j)
-                    $remainingLine = $line.Substring($j)
+                    $prefixBeforeString = $line.Substring(0, $j + 1)
+                    $remainingLine = $line.Substring($j + 1)
 
                     $multilineEndMatch = $null
                     while ($i -lt $lines.Count) {
-                        # Search for closing ''' starting at offset 1 to skip the opening delimiter for empty strings
-                        $multilineEndMatch = [regex]::Match($remainingLine, "'''", 1)
+                        $multilineEndMatch = [regex]::Match($remainingLine, "'''")
                         
                         if ($multilineEndMatch.Success) {
                             # String ends within this remaining content
-                            # Preserve everything after the closing ''' in case there's more content on the line
                             $line = $prefixBeforeString + $remainingLine
-                            # Reset j to continue checking after the string
                             $j = $prefixBeforeString.Length + $multilineEndMatch.Index + 2
                             break
                         }

--- a/src/DeployBicepHelpers.psm1
+++ b/src/DeployBicepHelpers.psm1
@@ -72,8 +72,9 @@ function Remove-BicepComments {
                         $multilineEndMatch = [regex]::Match($remainingLine, "'''")
                         
                         if ($multilineEndMatch.Success -and $multilineEndMatch.Index -gt 0) {
-                            # String ends within this line
-                            $line = $prefixBeforeString + $remainingLine.Substring(0, $multilineEndMatch.Index + 3)
+                            # String ends within this remaining content
+                            # Preserve everything after the closing ''' in case there's more content on the line
+                            $line = $prefixBeforeString + $remainingLine
                             # Reset j to continue checking after the string
                             $j = $prefixBeforeString.Length + $multilineEndMatch.Index + 2
                             break

--- a/src/DeployBicepHelpers.psm1
+++ b/src/DeployBicepHelpers.psm1
@@ -69,9 +69,10 @@ function Remove-BicepComments {
 
                     $multilineEndMatch = $null
                     while ($i -lt $lines.Count) {
-                        $multilineEndMatch = [regex]::Match($remainingLine, "'''")
+                        # Search for closing ''' starting at offset 1 to skip the opening delimiter for empty strings
+                        $multilineEndMatch = [regex]::Match($remainingLine, "'''", 1)
                         
-                        if ($multilineEndMatch.Success -and $multilineEndMatch.Index -gt 0) {
+                        if ($multilineEndMatch.Success) {
                             # String ends within this remaining content
                             # Preserve everything after the closing ''' in case there's more content on the line
                             $line = $prefixBeforeString + $remainingLine

--- a/src/tests/Remove-BicepComments.tests.ps1
+++ b/src/tests/Remove-BicepComments.tests.ps1
@@ -318,7 +318,7 @@ var interpolated = $'''with ${interpolation}'''
                 expected = "var msg = $'not interpolated'"
             }
             @{
-                scenario = "single-line comment in the middle of multiline strings"
+                scenario = "single-line comment after first multiline string removes remaining content"
                 content  = "var str1 = $'''test''' // comment in middle var str2 = $'''test2'''"
                 expected = "var str1 = $'''test'''"
             }

--- a/src/tests/Remove-BicepComments.tests.ps1
+++ b/src/tests/Remove-BicepComments.tests.ps1
@@ -345,6 +345,31 @@ config1: value1
                 content  = "var a = $'''first''' // comment1 var b = $'''second''' /* comment2 */ var c = $'''third'''"
                 expected = "var a = $'''first'''"
             }
+            @{
+                scenario = "empty multiline interpolated string"
+                content  = "var empty = $''''''"
+                expected = "var empty = $''''''"
+            }
+            @{
+                scenario = "empty regular multiline string"
+                content  = "var empty = ''''''"
+                expected = "var empty = ''''''"
+            }
+            @{
+                scenario = "empty multiline interpolated string with comment after"
+                content  = "var empty = $'''''' // this is a comment"
+                expected = "var empty = $''''''"
+            }
+            @{
+                scenario = "empty regular multiline string with comment after"
+                content  = "var empty = '''''' // this is a comment"
+                expected = "var empty = ''''''"
+            }
+            @{
+                scenario = "empty multiline interpolated string with multi-line comment after"
+                content  = "var empty = $'''''' /* comment */ var other = 1"
+                expected = "var empty = $''''''  var other = 1"
+            }
 
         ) {
             param ($content, $expected)

--- a/src/tests/Remove-BicepComments.tests.ps1
+++ b/src/tests/Remove-BicepComments.tests.ps1
@@ -203,4 +203,149 @@ var example = '''string wit'h \'quote\'
             | Should -BeExactly $expected
         }
     }
+
+    Context "Multiline Interpolated Strings (Bicep v0.40.2+)" {
+        It "Should handle <scenario> correctly" -TestCases @(
+            @{
+                scenario = "basic multiline interpolated string with single dollar"
+                content  = @'
+var message = $'''
+Hello, this is
+a multiline string
+with ${variable}'''
+'@
+                expected = @'
+var message = $'''
+Hello, this is
+a multiline string
+with ${variable}'''
+'@
+            }
+            @{
+                scenario = "multiline interpolated string on single line"
+                content  = "var message = $'''hello ${world}'''"
+                expected = "var message = $'''hello ${world}'''"
+            }
+            @{
+                scenario = "multiline interpolated string ends with comment after"
+                content  = "var message = $'''hello''' // this is a comment"
+                expected = "var message = $'''hello'''"
+            }
+            @{
+                scenario = "escaped dollars in multiline string"
+                content  = @'
+var message = $$'''
+Price: $$100
+Not interpolated: $${var}'''
+'@
+                expected = @'
+var message = $$'''
+Price: $$100
+Not interpolated: $${var}'''
+'@
+            }
+            @{
+                scenario = "double dollar escape on single line"
+                content  = "var message = $$'''cost is $$50'''"
+                expected = "var message = $$'''cost is $$50'''"
+            }
+            @{
+                scenario = "preserves comments inside multiline interpolated string"
+                content  = @'
+var documentation = $'''
+This is code:
+var x = 1 // not a comment
+/* also not */ a comment
+'''
+'@
+                expected = @'
+var documentation = $'''
+This is code:
+var x = 1 // not a comment
+/* also not */ a comment
+'''
+'@
+            }
+            @{
+                scenario = "multiline interpolated string followed by code with comment"
+                content  = "var str1 = $'''test''' var str2 = $'''test2''' // comment"
+                expected = "var str1 = $'''test''' var str2 = $'''test2'''"
+            }
+            @{
+                scenario = "nested quotes in multiline interpolated string"
+                content  = @'
+var quoted = $'''
+This has 'single quotes'
+and "double quotes" inside'''
+'@
+                expected = @'
+var quoted = $'''
+This has 'single quotes'
+and "double quotes" inside'''
+'@
+            }
+            @{
+                scenario = "multiline interpolated string with backslashes"
+                content  = @'
+var paths = $'''
+/path/to/file
+C:\Windows\System32'''
+'@
+                expected = @'
+var paths = $'''
+/path/to/file
+C:\Windows\System32'''
+'@
+            }
+            @{
+                scenario = "multiline string followed by interpolated multiline string"
+                content  = @'
+var plain = '''no interpolation'''
+var interpolated = $'''with ${interpolation}'''
+'@
+                expected = @'
+var plain = '''no interpolation'''
+var interpolated = $'''with ${interpolation}'''
+'@
+            }
+            @{
+                scenario = "dollar sign without triple quotes (not interpolated)"
+                content  = "var msg = $'not interpolated'"
+                expected = "var msg = $'not interpolated'"
+            }
+            @{
+                scenario = "single-line comment in the middle of multiline strings"
+                content  = "var str1 = $'''test''' // comment in middle var str2 = $'''test2'''"
+                expected = "var str1 = $'''test'''"
+            }
+            @{
+                scenario = "multi-line comment between two multiline interpolated strings"
+                content  = "var str1 = $'''test''' /* comment between */ var str2 = $'''test2'''"
+                expected = "var str1 = $'''test'''  var str2 = $'''test2'''"
+            }
+            @{
+                scenario = "complex scenario with multiline string before, comment, and string after"
+                content  = @'
+var config1 = $'''
+config1: value1
+''' // setup comment var config2 = $'''config2: value2'''
+'@
+                expected = @'
+var config1 = $'''
+config1: value1
+'''
+'@
+            }
+            @{
+                scenario = "multiple alternating strings and comments"
+                content  = "var a = $'''first''' // comment1 var b = $'''second''' /* comment2 */ var c = $'''third'''"
+                expected = "var a = $'''first'''"
+            }
+
+        ) {
+            param ($content, $expected)
+            Remove-BicepComments -Content $content
+            | Should -BeExactly $expected
+        }
+    }
 }

--- a/src/tests/Remove-BicepComments.tests.ps1
+++ b/src/tests/Remove-BicepComments.tests.ps1
@@ -231,7 +231,7 @@ var message = $'''hello ${world}'''
 '@
             }
             @{
-                scenario = "multiline interpolated string ends with comment after"
+                scenario = "multiline interpolated string with comment after closing delimiter"
                 content  = "var message = $'''hello''' // this is a comment"
                 expected = "var message = $'''hello'''"
             }

--- a/src/tests/Remove-BicepComments.tests.ps1
+++ b/src/tests/Remove-BicepComments.tests.ps1
@@ -223,8 +223,12 @@ with ${variable}'''
             }
             @{
                 scenario = "multiline interpolated string on single line"
-                content  = "var message = $'''hello ${world}'''"
-                expected = "var message = $'''hello ${world}'''"
+                content  = @'
+var message = $'''hello ${world}'''
+'@
+                expected = @'
+var message = $'''hello ${world}'''
+'@
             }
             @{
                 scenario = "multiline interpolated string ends with comment after"
@@ -246,8 +250,8 @@ Not interpolated: $${var}'''
             }
             @{
                 scenario = "double dollar escape on single line"
-                content  = "var message = $$'''cost is $$50'''"
-                expected = "var message = $$'''cost is $$50'''"
+                content  = "var message = `$`$'''cost is `$`$50'''"
+                expected = "var message = `$`$'''cost is `$`$50'''"
             }
             @{
                 scenario = "preserves comments inside multiline interpolated string"

--- a/src/tests/Remove-BicepComments.tests.ps1
+++ b/src/tests/Remove-BicepComments.tests.ps1
@@ -370,6 +370,36 @@ config1: value1
                 content  = "var empty = $'''''' /* comment */ var other = 1"
                 expected = "var empty = $''''''  var other = 1"
             }
+            @{
+                scenario = "regular non-empty multiline string with comment after closing delimiter"
+                content  = "var message = '''hello''' // this is a comment"
+                expected = "var message = '''hello'''"
+            }
+            @{
+                scenario = "regular multiline string followed by code with comment"
+                content  = "var str1 = '''test''' var str2 = '''test2''' // comment"
+                expected = "var str1 = '''test''' var str2 = '''test2'''"
+            }
+            @{
+                scenario = "regular multiline string with multi-line comment after"
+                content  = "var str1 = '''test''' /* comment between */ var str2 = '''test2'''"
+                expected = "var str1 = '''test'''  var str2 = '''test2'''"
+            }
+            @{
+                scenario = "multiple alternating regular strings and comments"
+                content  = "var a = '''first''' // comment1 var b = '''second''' /* comment2 */ var c = '''third'''"
+                expected = "var a = '''first'''"
+            }
+            @{
+                scenario = "mixed interpolated and regular multiline strings with comments"
+                content  = "var a = $'''interpolated''' // comment var b = '''regular'''"
+                expected = "var a = $'''interpolated'''"
+            }
+            @{
+                scenario = "regular multiline string on single line with nested content and comment"
+                content  = "var code = '''var x = 1 // this is part of the string''' // external comment"
+                expected = "var code = '''var x = 1 // this is part of the string'''"
+            }
 
         ) {
             param ($content, $expected)


### PR DESCRIPTION
This pull request enhances the handling of multiline interpolated strings in Bicep files, particularly for scenarios introduced in Bicep v0.40.2 and later. The main improvements include updating the comment removal logic to correctly process multiline interpolated strings and adding comprehensive tests to cover a wide range of cases.

### Improvements to multiline interpolated string handling

* Updated the `Remove-BicepComments` function to properly search for the closing delimiter in multiline interpolated strings, ensuring that content after the closing `'''` is preserved and that the function handles empty strings and strings with additional content correctly.

### Expanded test coverage for multiline interpolated strings

* Added a new test context in `Remove-BicepComments.tests.ps1` with multiple scenarios covering basic usage, edge cases, comment handling, escapes, nested quotes, and complex combinations of multiline interpolated strings and comments. This ensures robust validation of the improved logic.